### PR TITLE
Add Evaluation ViewSet with filters

### DIFF
--- a/restapi/urls.py
+++ b/restapi/urls.py
@@ -1,0 +1,11 @@
+from django.urls import path, include
+
+from rest_framework import routers
+from . import views
+
+router = routers.DefaultRouter()
+
+router.register('recordings', views.AnnotatedRecordingViewSet)
+router.register('evaluations', views.EvaluationViewSet)
+
+urlpatterns = [ path('', include(router.urls)) ]

--- a/restapi/views.py
+++ b/restapi/views.py
@@ -86,6 +86,28 @@ class AnnotatedRecordingViewSet(viewsets.ModelViewSet):
     filter_backends = (filters.DjangoFilterBackend,)
     filter_class = AnnotatedRecordingFilter
 
+class EvaluationFilter(filters.FilterSet):
+    EVAL_CHOICES = (
+    ('correct', 'Correct'),
+    ('incorrect', 'Incorrect'))
+
+    surah = filters.NumberFilter(field_name='associated_recording__surah_num')
+    ayah = filters.NumberFilter(field_name='associated_recording__ayah_num')
+    evaluation = filters.ChoiceFilter(choices=EVAL_CHOICES)
+    associated_recording = filters.ModelChoiceFilter(queryset=AnnotatedRecording.objects.all())
+
+    class Meta:
+        model = Evaluation
+        fields = ['surah', 'ayah', 'evaluation', 'associated_recording']
+
+class EvaluationViewSet(viewsets.ModelViewSet):
+    """API to handle query parameters
+    Example: api/v1/evaluations/?surah=114&ayah=1&evaluation=correct
+    """
+    serializer_class = EvaluationSerializer
+    queryset = Evaluation.objects.all()
+    filter_backends = (filters.DjangoFilterBackend,)
+    filter_class=EvaluationFilter
 
 class DemographicInformationViewList(APIView):
     """API endpoint that allows demographic information to be viewed or edited.

--- a/tarteel/urls.py
+++ b/tarteel/urls.py
@@ -4,6 +4,7 @@ from django.conf.urls import include
 from django.conf.urls import url
 from django.conf.urls.static import static
 from django.contrib import admin
+from django.urls import path, include
 # REST
 from rest_framework import routers
 # Tarteel
@@ -15,12 +16,10 @@ import restapi.views
 router = routers.DefaultRouter()
 # router.register(r'users', restapi.views.UserViewSet)
 # router.register(r'groups', restapi.views.GroupViewSet)
-router.register(r'api/v1/recordings', restapi.views.AnnotatedRecordingViewSet,
-                base_name='recordings')
-router.register(r'api/v1/evaluations', restapi.views.EvaluationViewSet,
-                base_name='evaluations')
 
 urlpatterns = [
+    # Rest API v1
+    path('api/v1/', include('restapi.urls')),
     # Top Level API
     url(r'^admin/', admin.site.urls),
     url(r'^api-auth/', include('rest_framework.urls', namespace='rest_framework')),

--- a/tarteel/urls.py
+++ b/tarteel/urls.py
@@ -17,6 +17,8 @@ router = routers.DefaultRouter()
 # router.register(r'groups', restapi.views.GroupViewSet)
 router.register(r'api/v1/recordings', restapi.views.AnnotatedRecordingViewSet,
                 base_name='recordings')
+router.register(r'api/v1/evaluations', restapi.views.EvaluationViewSet,
+                base_name='evaluations')
 
 urlpatterns = [
     # Top Level API


### PR DESCRIPTION
Add a ViewSet for the Evaluation model, with an endpoint at
api/v1/evaluations. Includes filters for surah, ayah, evaluation result
and associated recording.

Also moves the new api/v1 ViewSet endpoints to a separate urls.py under the
restapi app.